### PR TITLE
Fix link of Binder button to the proper branch

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -28,6 +28,7 @@ repository:
   url                         : https://github.com/shimming-toolbox/B1-shimming
   path_to_book                : "book"
   branch                      : "main"
+
 binder:
   binderhub_url               : "https://mybinder.org"
   text                        : "Launch binder"

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -27,7 +27,7 @@ notebook_interface            : "notebook"
 repository:
   url                         : https://github.com/shimming-toolbox/B1-shimming
   path_to_book                : "book"
-
+  branch                      : "main"
 binder:
   binderhub_url               : "https://mybinder.org"
   text                        : "Launch binder"


### PR DESCRIPTION
## Bug
If you click the Binder button in the Jupyter Book (eg, https://shimming-toolbox.github.io/B1-shimming/content/b1_mapping.html), it goes to MyBinder but it cannot find the branch. The link it points to is here: https://mybinder.org/v2/gh/shimming-toolbox/B1-shimming/master?urlpath=tree/book/content/b1_mapping.ipynb

<img width="1378" alt="Screen Shot 2022-04-06 at 1 22 54 PM" src="https://user-images.githubusercontent.com/1421029/162021783-f6202e3c-dd34-4e60-b6b0-899a8292497b.png">


## Expected behafviour
It should point here https://mybinder.org/v2/gh/shimming-toolbox/B1-shimming/main?urlpath=tree/book/content/b1_mapping.ipynb, which opens the binder session succesfully.


<img width="1390" alt="Screen Shot 2022-04-06 at 1 25 59 PM" src="https://user-images.githubusercontent.com/1421029/162022339-edda697a-3575-4581-a2c0-fd77da6200b6.png">

## Solution
Explicitely set the branch to "main" in the Jupyter Book config file, as if it is omitted it defaults to the "master" branch, which does not exist in this repo. See here for documentation (comment in the code block "Add a button to suggest edits"): https://jupyterbook.org/basics/repository.html?highlight=branch 